### PR TITLE
Fix BindCraft dependency so the binder pipeline imports

### DIFF
--- a/FoldCraft_binder.py
+++ b/FoldCraft_binder.py
@@ -30,8 +30,17 @@ from colabdesign.mpnn import mk_mpnn_model
 from biopython_utils import *
 import warnings
 
-from BindCraft.functions import *
-pr.init(f'-ignore_unrecognized_res -ignore_zero_occupancy -mute all -holes:dalphaball "./DAlphaBall.gcc" -corrections::beta_nov16 true -relax:default_repeats 1')
+# BindCraft provides the PyRosetta relax + interface-scoring helpers reused
+# below. It is not pip-installable, so locate the checkout (created by
+# install_foldcraft.sh or pointed to via $BINDCRAFT_PATH), put it on sys.path,
+# and import only what we use -- avoiding the previous `import *`, which both
+# failed when BindCraft was absent and shadowed FoldCraft's own biopython_utils.
+from bindcraft_deps import ensure_bindcraft_importable, dalphaball_path
+ensure_bindcraft_importable()
+import pyrosetta as pr
+from BindCraft.functions.pyrosetta_utils import pr_relax, score_interface
+
+pr.init(f'-ignore_unrecognized_res -ignore_zero_occupancy -mute all -holes:dalphaball "{dalphaball_path()}" -corrections::beta_nov16 true -relax:default_repeats 1')
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Run fold-conditioned binder design")

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Then run code below to download all requirements, ColabDesign and AlphaFold2 wei
 
 NOTE: AlphaFold3, which has been used in the manuscript for VHH design benchmarking, should be installed separately as described in official <a href='https://github.com/google-deepmind/alphafold3'>repository</a>
 
+NOTE: The PyRosetta-based binder pipeline (`FoldCraft_binder.py`) reuses interface relaxation and scoring from <a href='https://github.com/martinpacesa/BindCraft'>BindCraft</a> (the `pr_relax` and `score_interface` functions, plus the bundled `DAlphaBall.gcc`). `install_foldcraft.sh` now clones BindCraft into the FoldCraft directory automatically. If you install manually, clone BindCraft alongside FoldCraft (or set the `BINDCRAFT_PATH` environment variable to its location). Set `BINDCRAFT_COMMIT` before running the installer to pin a specific BindCraft revision for reproducibility.
+
 <h2>Running FoldCraft locally</h2>
 
 To run FoldCraft locally you will need the following files:

--- a/bindcraft_deps.py
+++ b/bindcraft_deps.py
@@ -1,0 +1,104 @@
+"""Locate and expose the BindCraft utilities that FoldCraft's PyRosetta pipeline needs.
+
+``FoldCraft_binder.py`` reuses two functions from Martin Pacesa's BindCraft
+(https://github.com/martinpacesa/BindCraft):
+
+  - ``pr_relax(pdb_file, relaxed_pdb_path)``
+  - ``score_interface(pdb_file, binder_chain="B")``
+
+plus PyRosetta itself (conventionally imported as ``pr``) and the bundled
+``DAlphaBall.gcc`` binary used for interface "holes" scoring.
+
+BindCraft is a collection of scripts, not a pip-installable package, so it has
+to be cloned and placed on ``sys.path`` (the import is ``BindCraft.functions``,
+which resolves as a namespace package when BindCraft's *parent* directory is on
+the path). Upstream FoldCraft relied on an implicit ``from BindCraft.functions
+import *`` that (a) was never installed by ``install_foldcraft.sh`` and (b)
+silently shadowed FoldCraft's own ``biopython_utils`` helpers. This module
+makes the dependency explicit and fails with an actionable message when it is
+missing.
+
+The path-resolution logic here is intentionally free of any PyRosetta/BindCraft
+import so it can be unit-tested on a machine without the GPU design stack.
+"""
+import os
+import sys
+
+BINDCRAFT_REPO_URL = "https://github.com/martinpacesa/BindCraft"
+
+
+def _bindcraft_candidates(explicit_path=None):
+    """Ordered list of directories that might be (or contain) the BindCraft repo."""
+    candidates = []
+    if explicit_path:
+        candidates.append(explicit_path)
+    env = os.environ.get("BINDCRAFT_PATH")
+    if env:
+        candidates.append(env)
+    # Installer default: a ``BindCraft`` checkout next to this file.
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(os.path.join(here, "BindCraft"))
+    return candidates
+
+
+def _is_bindcraft_repo(path):
+    """True if ``path`` is a BindCraft checkout (has functions/__init__.py)."""
+    return os.path.isfile(os.path.join(path, "functions", "__init__.py"))
+
+
+def find_bindcraft_repo(explicit_path=None):
+    """Return the absolute path to the BindCraft repository directory.
+
+    A candidate matches if it either *is* a BindCraft checkout or *contains* a
+    ``BindCraft`` subdirectory that is one. Raises ``ImportError`` with install
+    instructions if none match.
+    """
+    for cand in _bindcraft_candidates(explicit_path):
+        cand = os.path.abspath(cand)
+        if _is_bindcraft_repo(cand):
+            return cand
+        nested = os.path.join(cand, "BindCraft")
+        if _is_bindcraft_repo(nested):
+            return nested
+    searched = [os.path.abspath(c) for c in _bindcraft_candidates(explicit_path)]
+    raise ImportError(
+        "FoldCraft's binder pipeline requires BindCraft, which was not found.\n"
+        "Re-run install_foldcraft.sh, or clone it manually:\n"
+        f"    git clone {BINDCRAFT_REPO_URL}\n"
+        "and/or set the BINDCRAFT_PATH environment variable to its location.\n"
+        f"Searched: {searched}"
+    )
+
+
+def ensure_bindcraft_importable(explicit_path=None):
+    """Put BindCraft's parent dir on ``sys.path`` so ``import BindCraft`` works.
+
+    Returns the BindCraft repository path. Idempotent.
+    """
+    repo = find_bindcraft_repo(explicit_path)
+    parent = os.path.dirname(repo)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    return repo
+
+
+def dalphaball_path(explicit_path=None):
+    """Absolute path to the DAlphaBall.gcc binary bundled with BindCraft.
+
+    Falls back to a ``./DAlphaBall.gcc`` in the current directory if present
+    (preserving upstream FoldCraft's behavior). Raises FileNotFoundError with
+    guidance otherwise.
+    """
+    repo = find_bindcraft_repo(explicit_path)
+    bundled = os.path.join(repo, "functions", "DAlphaBall.gcc")
+    if os.path.isfile(bundled):
+        return bundled
+    cwd_copy = os.path.abspath("DAlphaBall.gcc")
+    if os.path.isfile(cwd_copy):
+        return cwd_copy
+    raise FileNotFoundError(
+        "DAlphaBall.gcc not found. It ships with BindCraft at "
+        "functions/DAlphaBall.gcc and is required for interface holes scoring. "
+        "Re-run install_foldcraft.sh to set it up.\n"
+        f"Looked for: {bundled} and {cwd_copy}"
+    )

--- a/install_foldcraft.sh
+++ b/install_foldcraft.sh
@@ -93,6 +93,25 @@ echo -e "Installing ColabDesign\n"
 pip3 install git+https://github.com/sokrypton/ColabDesign.git --no-deps || { echo -e "Error: Failed to install ColabDesign"; exit 1; }
 python -c "import colabdesign" >/dev/null 2>&1 || { echo -e "Error: colabdesign module not found after installation"; exit 1; }
 
+# install BindCraft (provides pr_relax / score_interface used by FoldCraft_binder.py)
+# BindCraft is not a pip package; clone it next to FoldCraft so that
+# `import BindCraft.functions` resolves. Set BINDCRAFT_COMMIT to pin a revision
+# for reproducibility (recommended); empty = default branch.
+echo -e "Installing BindCraft\n"
+BINDCRAFT_COMMIT="${BINDCRAFT_COMMIT:-}"
+bindcraft_dir="${install_dir}/BindCraft"
+if [ ! -d "${bindcraft_dir}" ]; then
+    git clone https://github.com/martinpacesa/BindCraft "${bindcraft_dir}" || { echo -e "Error: Failed to clone BindCraft"; exit 1; }
+fi
+if [ -n "${BINDCRAFT_COMMIT}" ]; then
+    git -C "${bindcraft_dir}" checkout "${BINDCRAFT_COMMIT}" || { echo -e "Error: Failed to checkout BindCraft commit ${BINDCRAFT_COMMIT}"; exit 1; }
+fi
+[ -f "${bindcraft_dir}/functions/__init__.py" ] || { echo -e "Error: BindCraft checkout is missing functions/__init__.py"; exit 1; }
+# DAlphaBall.gcc (interface holes scoring) ships with BindCraft; ensure executable.
+[ -f "${bindcraft_dir}/functions/DAlphaBall.gcc" ] || { echo -e "Error: BindCraft is missing functions/DAlphaBall.gcc"; exit 1; }
+chmod +x "${bindcraft_dir}/functions/DAlphaBall.gcc" || { echo -e "Warning: could not chmod +x DAlphaBall.gcc"; }
+python -c "import sys; sys.path.insert(0, '${install_dir}'); from bindcraft_deps import find_bindcraft_repo; print('BindCraft at', find_bindcraft_repo())" || { echo -e "Error: BindCraft not importable via bindcraft_deps"; exit 1; }
+
 # AlphaFold2 weights
 echo -e "Downloading AlphaFold2 model weights \n"
 params_dir="${install_dir}/params"

--- a/tests/test_bindcraft_deps.py
+++ b/tests/test_bindcraft_deps.py
@@ -1,0 +1,86 @@
+"""Tests for the BindCraft locator (bindcraft_deps.py).
+
+These exercise only the path-resolution logic, which is deliberately free of
+PyRosetta/BindCraft imports, so they run on a plain CPU machine. We fake a
+BindCraft checkout on disk rather than cloning the real one.
+"""
+import os
+import sys
+
+import pytest
+
+# Make the repo root importable so `import bindcraft_deps` works when this test
+# runs on its own (independently of the test-suite's conftest.py).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import bindcraft_deps as bd
+
+
+def _make_fake_bindcraft(root, with_dalphaball=True):
+    """Create a minimal BindCraft checkout layout under ``root``/BindCraft."""
+    repo = os.path.join(root, "BindCraft")
+    functions = os.path.join(repo, "functions")
+    os.makedirs(functions)
+    open(os.path.join(functions, "__init__.py"), "w").close()
+    if with_dalphaball:
+        open(os.path.join(functions, "DAlphaBall.gcc"), "w").close()
+    return repo
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    # Ensure a stray BINDCRAFT_PATH in the real environment can't leak in.
+    monkeypatch.delenv("BINDCRAFT_PATH", raising=False)
+
+
+class TestFindBindcraftRepo:
+    def test_explicit_path_is_the_repo(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path)
+        assert bd.find_bindcraft_repo(repo) == os.path.abspath(repo)
+
+    def test_explicit_path_is_the_parent(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path)
+        # Passing the parent dir should also resolve to the nested BindCraft.
+        assert bd.find_bindcraft_repo(str(tmp_path)) == os.path.abspath(repo)
+
+    def test_env_var_used(self, tmp_path, monkeypatch):
+        repo = _make_fake_bindcraft(tmp_path)
+        monkeypatch.setenv("BINDCRAFT_PATH", str(tmp_path))
+        assert bd.find_bindcraft_repo() == os.path.abspath(repo)
+
+    def test_missing_raises_with_instructions(self, tmp_path):
+        empty = tmp_path / "nothing"
+        empty.mkdir()
+        with pytest.raises(ImportError) as exc:
+            bd.find_bindcraft_repo(str(empty))
+        msg = str(exc.value)
+        assert "git clone" in msg and "BindCraft" in msg
+
+
+class TestEnsureImportable:
+    def test_inserts_parent_on_syspath_and_is_idempotent(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path)
+        parent = os.path.dirname(repo)
+        original = list(sys.path)
+        try:
+            bd.ensure_bindcraft_importable(repo)
+            assert parent in sys.path
+            count_after_first = sys.path.count(parent)
+            bd.ensure_bindcraft_importable(repo)
+            assert sys.path.count(parent) == count_after_first  # no duplicate
+        finally:
+            sys.path[:] = original
+
+
+class TestDalphaballPath:
+    def test_returns_bundled_binary(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path, with_dalphaball=True)
+        expected = os.path.join(repo, "functions", "DAlphaBall.gcc")
+        assert bd.dalphaball_path(repo) == expected
+
+    def test_missing_binary_raises(self, tmp_path, monkeypatch):
+        repo = _make_fake_bindcraft(tmp_path, with_dalphaball=False)
+        # Run from a dir with no ./DAlphaBall.gcc fallback either.
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            bd.dalphaball_path(repo)


### PR DESCRIPTION
## Problem

`FoldCraft_binder.py` does `from BindCraft.functions import *`, but `install_foldcraft.sh` never installs or clones BindCraft — so the PyRosetta binder pipeline fails to import out of the box for anyone who clones the repo. Additionally, that wildcard import sits *after* `from biopython_utils import *`, so it silently shadows FoldCraft's own `hotspot_residues` / `calculate_clash_score` with BindCraft's copies.

## Fix

- **`bindcraft_deps.py` (new):** locates a BindCraft checkout (explicit arg → `$BINDCRAFT_PATH` → a `./BindCraft` next to the repo), puts its parent on `sys.path` so `import BindCraft.functions` resolves, and resolves the bundled `DAlphaBall.gcc`. Raises actionable errors if BindCraft is missing. The path logic has no PyRosetta/BindCraft import, so it is unit-testable on a CPU-only machine.
- **`FoldCraft_binder.py`:** replaces the wildcard with explicit imports of only the symbols actually used — `pr_relax`, `score_interface`, and `pyrosetta as pr` — and resolves the DAlphaBall path via `dalphaball_path()` instead of hardcoding `./DAlphaBall.gcc`. FoldCraft now uses its own `biopython_utils` helpers (verified equivalent to BindCraft's: same signatures, defaults, and return structures).
- **`install_foldcraft.sh`:** clones BindCraft (pinnable via `$BINDCRAFT_COMMIT`), verifies `functions/__init__.py` and `DAlphaBall.gcc`, makes the binary executable, and checks importability.
- **`README.md`:** documents the BindCraft requirement for the binder pipeline.
- **7 unit tests** for the locator using a faked checkout (`tests/test_bindcraft_deps.py`); the test is self-contained and runs with `pytest tests/test_bindcraft_deps.py`.

## Verification

- Locator unit tests pass on CPU (`7 passed`).
- Function signatures checked against BindCraft source (`pr_relax(pdb_file, relaxed_pdb_path)`, `score_interface(pdb_file, binder_chain="B")`).
- **Not** runtime-verified end-to-end: PyRosetta + GPU AlphaFold weights are needed for a full design run and aren't available in a CPU-only environment. Static checks (imports parse, installer shell syntax, signature match) and the locator tests pass.

This PR is independent of the companion test-suite PR and can be merged on its own, in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)