### PR TITLE
Add a CPU-only test suite for the helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test / tooling caches
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+
+# Design pipeline outputs (trajectories, mpnn samples, results)
+# These are large and run-specific; keep them out of version control.
+**/traj/
+**/mpnn/
+**/designs/
+**/relaxed/
+*.pickle
+results*.csv
+fold_cond_cmap*.npy
+
+# OS noise
+.DS_Store

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Development / test dependencies for the GPU-free test layer.
+#
+# These cover the pure helper functions (biopython_utils.py) and the test
+# suite. They do NOT include the heavy design-time stack (jax, colabdesign,
+# alphafold weights, pyrosetta, BindCraft) — that is GPU-only and installed via
+# install_foldcraft.sh. See tests/README.md.
+#
+# Install:  python -m venv .venv && ./.venv/bin/pip install -r requirements-dev.txt
+biopython==1.87
+numpy==2.4.6
+scipy==1.17.1
+pytest==9.1.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,48 @@
+# FoldCraft test suite
+
+This suite was added to give the project a regression safety net before we
+refactor or tune the design pipeline. Upstream FoldCraft shipped **no tests**.
+
+## What is covered
+
+These are **characterization tests**: they assert the *current* behavior of the
+GPU-free helper functions so that refactors and performance/accuracy work do not
+silently change residue selection, interface detection, or scoring.
+
+Covered today (all CPU-only, run on a laptop in seconds):
+
+- `biopython_utils.set_range` — hotspot/mask range parsing
+- `biopython_utils.calculate_percentages` — secondary-structure fractions
+- `biopython_utils.validate_design_sequence` — composition notes
+- `biopython_utils.calculate_clash_score` — clash counting (real PDB fixtures)
+- `biopython_utils.hotspot_residues` — interface detection (synthetic complex)
+- `biopython_utils.target_pdb_rmsd` — CA RMSD after superposition
+
+## Known issues the tests pin (not yet fixed)
+
+Some tests document behavior that is arguably a **latent bug**. They are named
+and commented with `BUG:` so the behavior is locked but flagged:
+
+- **`set_range` upper bound is exclusive.** `"39-45"` expands to `39..44`,
+  dropping residue 45; `"80-81"` yields only `[80]`; `"80-80"` yields `[]`.
+  This silently narrows every hotspot/mask window by one residue at the top and
+  is accuracy-relevant (it decides which residues the cmap loss conditions on).
+  Fixing it will change design inputs, so it must be done deliberately, with the
+  test updated in the same commit and a baseline re-run to confirm the effect.
+
+## What is NOT covered yet
+
+The two design drivers (`FoldCraft.py`, `FoldCraft_binder.py`) are monolithic
+`main()` functions requiring a GPU, AlphaFold2 weights, `colabdesign`, and the
+side-loaded `BindCraft` package (`from BindCraft.functions import *`, which is
+neither vendored nor declared). They have no importable seams. Covering them
+requires the planned refactor into testable units; that work is tracked
+separately.
+
+## Running
+
+```bash
+python -m venv .venv
+./.venv/bin/pip install -r requirements-dev.txt
+./.venv/bin/python -m pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared fixtures for the FoldCraft test suite.
+
+These tests are *characterization* tests: they lock in the CURRENT behavior of
+the GPU-free helper functions so we can refactor and tune the design pipeline
+without silently changing residue selection, interface detection, or scoring.
+Where current behavior looks like a latent bug, the test documents it
+explicitly (see ``test_biopython_utils.py``) rather than asserting the
+"intended" behavior — so a future fix will trip the test and force a conscious
+decision.
+"""
+import os
+import sys
+
+import pytest
+from Bio.PDB import PDBIO
+from Bio.PDB.Structure import Structure
+from Bio.PDB.Model import Model
+from Bio.PDB.Chain import Chain
+from Bio.PDB.Residue import Residue
+from Bio.PDB.Atom import Atom
+
+# Make the repo root importable so `import biopython_utils` works regardless of
+# where pytest is invoked from.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+TEST_PDB_DIR = os.path.join(REPO_ROOT, "framework", "test")
+
+
+@pytest.fixture(scope="session")
+def pdb_1qys():
+    """Path to the shipped single-chain Top7 (1QYS) example structure."""
+    path = os.path.join(TEST_PDB_DIR, "1qys.pdb")
+    assert os.path.exists(path), f"missing test fixture: {path}"
+    return path
+
+
+@pytest.fixture(scope="session")
+def pdb_pdl1():
+    """Path to the shipped single-chain PD-L1 example structure."""
+    path = os.path.join(TEST_PDB_DIR, "pd_l1.pdb")
+    assert os.path.exists(path), f"missing test fixture: {path}"
+    return path
+
+
+def _add_residue(chain, resseq, resname, atoms):
+    """Add a residue with the given (name, (x, y, z)) atoms to a chain."""
+    res = Residue((" ", resseq, " "), resname, "")
+    for i, (atom_name, coord) in enumerate(atoms):
+        atom = Atom(
+            atom_name,
+            coord,
+            0.0,          # bfactor
+            1.0,          # occupancy
+            " ",          # altloc
+            atom_name,    # fullname
+            i,            # serial_number
+            element=atom_name[0],
+        )
+        res.add(atom)
+    chain.add(res)
+    return res
+
+
+@pytest.fixture()
+def two_chain_complex(tmp_path):
+    """A minimal 2-chain complex written to disk, with a known interface.
+
+    Layout (CA-only, coordinates in Angstrom):
+      - chain A (target): residue 1 ALA at the origin.
+      - chain B (binder): residue 1 GLY ~3 A from chain A  -> interface contact
+                          residue 2 LEU ~20 A away          -> NOT a contact
+
+    With a 4.0 A cutoff, ``hotspot_residues(pdb, "B")`` should report exactly
+    binder residue 1 (GLY -> "G"). This pins interface detection, which drives
+    the non-interface ProteinMPNN redesign in the design pipeline.
+    """
+    structure = Structure("mini")
+    model = Model(0)
+    structure.add(model)
+
+    chain_a = Chain("A")
+    chain_b = Chain("B")
+    model.add(chain_a)
+    model.add(chain_b)
+
+    _add_residue(chain_a, 1, "ALA", [("CA", (0.0, 0.0, 0.0))])
+    _add_residue(chain_b, 1, "GLY", [("CA", (3.0, 0.0, 0.0))])
+    _add_residue(chain_b, 2, "LEU", [("CA", (20.0, 0.0, 0.0))])
+
+    out = tmp_path / "mini_complex.pdb"
+    io = PDBIO()
+    io.set_structure(structure)
+    io.save(str(out))
+    return str(out)

--- a/tests/test_biopython_utils.py
+++ b/tests/test_biopython_utils.py
@@ -1,0 +1,135 @@
+"""Characterization tests for biopython_utils.py.
+
+Goal: lock the CURRENT behavior of the GPU-free helpers before we refactor or
+tune the design pipeline. Several tests document behavior that is arguably a
+bug (notably the exclusive upper bound in ``set_range``); they are marked with
+a `BUG:` note. When we deliberately fix one, the corresponding test should be
+updated in the same commit so the change is explicit and reviewed.
+"""
+import pytest
+
+import biopython_utils as bu
+
+
+# ---------------------------------------------------------------------------
+# set_range  -- parses hotspot/mask range strings like "39-45,80,90-102"
+# This drives every hotspot/mask selection, so its semantics are
+# accuracy-critical: it decides which residues the cmap loss conditions on.
+# ---------------------------------------------------------------------------
+class TestSetRange:
+    def test_single_residue(self):
+        assert bu.set_range("80") == [80]
+
+    def test_comma_separated_singletons(self):
+        assert bu.set_range("80,90,102") == [80, 90, 102]
+
+    def test_range_is_upper_bound_EXCLUSIVE(self):
+        # BUG (characterized, not endorsed): "39-45" expands to 39..44 and
+        # DROPS the endpoint 45, because the implementation uses
+        # range(start, end) with no +1. A user typing "39-45" almost certainly
+        # means residues 39 through 45 inclusive. This silently narrows every
+        # hotspot/mask window by one residue at the top.
+        assert bu.set_range("39-45") == [39, 40, 41, 42, 43, 44]
+        assert 45 not in bu.set_range("39-45")
+
+    def test_mixed_ranges_and_singletons(self):
+        # Singletons keep their value; ranges drop their endpoint.
+        assert bu.set_range("14-30,80-81,90-102") == (
+            list(range(14, 30)) + [80] + list(range(90, 102))
+        )
+
+    def test_single_width_range_yields_empty(self):
+        # BUG (characterized): "80-81" yields only [80]; "80-80" yields [].
+        assert bu.set_range("80-81") == [80]
+        assert bu.set_range("80-80") == []
+
+    def test_order_preserved(self):
+        assert bu.set_range("90-92,10") == [90, 91, 10]
+
+
+# ---------------------------------------------------------------------------
+# calculate_percentages -- pure arithmetic for secondary-structure fractions
+# ---------------------------------------------------------------------------
+class TestCalculatePercentages:
+    def test_basic_split(self):
+        # total=10, helix=5, sheet=3 -> loop=2
+        assert bu.calculate_percentages(10, 5, 3) == (50.0, 30.0, 20.0)
+
+    def test_zero_total_is_safe(self):
+        assert bu.calculate_percentages(0, 0, 0) == (0, 0, 0)
+
+    def test_all_helix(self):
+        assert bu.calculate_percentages(4, 4, 0) == (100.0, 0.0, 0.0)
+
+    def test_rounding_to_two_decimals(self):
+        # 1/3 -> 33.33
+        h, s, l = bu.calculate_percentages(3, 1, 1)
+        assert h == 33.33 and s == 33.33 and l == 33.33
+
+
+# ---------------------------------------------------------------------------
+# validate_design_sequence -- composition notes for a designed sequence
+# ---------------------------------------------------------------------------
+class TestValidateDesignSequence:
+    def test_clean_high_absorption_sequence_no_notes(self):
+        # Tryptophan-rich sequence => high extinction => no absorption warning.
+        settings = {"omit_AAs": ""}
+        notes = bu.validate_design_sequence("WWWWYYYY", 0, settings)
+        assert notes == ""
+
+    def test_clash_note(self):
+        settings = {"omit_AAs": ""}
+        notes = bu.validate_design_sequence("WWWWYYYY", 3, settings)
+        assert "clashes" in notes
+
+    def test_omitted_aa_flagged(self):
+        settings = {"omit_AAs": "C"}
+        notes = bu.validate_design_sequence("WWCWYY", 0, settings)
+        assert "Contains: C" in notes
+
+    def test_low_absorption_suggests_tryptophan(self):
+        settings = {"omit_AAs": ""}
+        notes = bu.validate_design_sequence("AAAAGGGG", 0, settings)
+        assert "tryptophane" in notes.lower()
+
+
+# ---------------------------------------------------------------------------
+# calculate_clash_score -- C-alpha / heavy-atom clash counting on a real PDB
+# ---------------------------------------------------------------------------
+class TestCalculateClashScore:
+    def test_real_structure_has_no_ca_clashes(self, pdb_1qys):
+        # A well-formed deposited structure should have no CA-CA clashes
+        # between non-adjacent residues at the 2.4 A default threshold.
+        assert bu.calculate_clash_score(pdb_1qys, only_ca=True) == 0
+
+    def test_returns_int(self, pdb_pdl1):
+        score = bu.calculate_clash_score(pdb_pdl1, only_ca=True)
+        assert isinstance(score, int)
+
+
+# ---------------------------------------------------------------------------
+# hotspot_residues -- interface residue detection (drives MPNN redesign mask)
+# ---------------------------------------------------------------------------
+class TestHotspotResidues:
+    def test_detects_only_close_binder_residue(self, two_chain_complex):
+        result = bu.hotspot_residues(two_chain_complex, binder_chain="B")
+        # Only binder residue 1 (GLY) is within 4.0 A of chain A.
+        assert result == {1: "G"}
+
+    def test_wider_cutoff_includes_far_residue(self, two_chain_complex):
+        # At a 25 A cutoff both binder residues contact chain A.
+        result = bu.hotspot_residues(
+            two_chain_complex, binder_chain="B", atom_distance_cutoff=25.0
+        )
+        assert set(result.keys()) == {1, 2}
+        assert result[2] == "L"
+
+
+# ---------------------------------------------------------------------------
+# target_pdb_rmsd -- CA RMSD after superposition
+# ---------------------------------------------------------------------------
+class TestTargetPdbRmsd:
+    def test_self_alignment_is_zero(self, pdb_1qys):
+        # Aligning a structure's chain A against itself must give ~0 RMSD.
+        rmsd = bu.target_pdb_rmsd(pdb_1qys, pdb_1qys, "A")
+        assert rmsd == 0.0


### PR DESCRIPTION
## Summary

Adds a small, fast, CPU-only test suite so the GPU-free helper functions have a regression net. There were previously no tests in the repo. None of the design/algorithm behavior is changed — these are **characterization tests** that lock in current behavior.

## What's covered

19 tests over `biopython_utils.py`, all laptop-runnable in well under a second:

- `set_range` — hotspot/mask range parsing
- `calculate_percentages` — secondary-structure fractions
- `validate_design_sequence` — composition notes
- `calculate_clash_score` — clash counting (uses the shipped `framework/test` PDBs)
- `hotspot_residues` — interface detection (synthetic 2-chain complex built in `conftest.py`)
- `target_pdb_rmsd` — CA RMSD after superposition

## A bug the tests document (not fixed here)

`set_range` uses `range(start, end)`, so its **upper bound is exclusive**: `"39-45"` expands to `39..44` (drops 45), `"80-81"` yields `[80]`, and `"80-80"` yields `[]`. This silently narrows every hotspot/mask window by one residue at the top. The tests pin this current behavior with `BUG:` notes rather than changing it, since fixing it alters design inputs and deserves its own change with before/after comparison. Happy to follow up with a fix PR if you'd like.

## Tooling

- `requirements-dev.txt` — pinned CPU-only test deps (kept separate from the GPU design stack)
- `pytest.ini`, `.gitignore` (ignores venvs and run-specific design outputs), `tests/README.md`

## Test results

```
19 passed
```

Run with:
```bash
python -m venv .venv && ./.venv/bin/pip install -r requirements-dev.txt
./.venv/bin/python -m pytest
```

This PR is independent of the companion BindCraft-fix PR and can be merged on its own, in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)