### PR TITLE
Refactor: extract fold-conditioned cmap into a tested module; drop os.system shell-outs

### DIFF
--- a/FoldCraft.py
+++ b/FoldCraft.py
@@ -28,6 +28,7 @@ import matplotlib.pyplot as plt
 from matplotlib import patches
 from colabdesign.mpnn import mk_mpnn_model
 from biopython_utils import *
+from cmap_utils import assemble_fold_conditioned_cmap, binarize_cmap
 import warnings
 
 
@@ -95,90 +96,64 @@ def main():
     mpnn_save = args.mpnn_save
 
     model_name = 'v_48_010'
-    try:
-        os.system(f'mkdir {folder_name}')
-    except:
-        pass
-        
+    os.makedirs(folder_name, exist_ok=True)
+
     if vhh:
+        # VHH path: binder cmap comes from the fixed VHH framework, the binder
+        # length is the 127-residue VHH scaffold, and the CDR (binder) hotspots
+        # are fixed -- any user-supplied binder_hotspots/binder_mask is ignored,
+        # matching the original behavior.
         load_np = np.load(f'framework/vhh.npy')
-        target_hotspots_np = np.array(set_range(target_hotspots))
         af_model = mk_afdesign_model(protocol="fixbb", use_templates=True)
         af_model.prep_inputs(pdb_filename=pdb_target_path,
                              ignore_missing=False,
                              chain = chain_id,)
-        
+
         target_len = af_model._len
         binder_len = 127
-        fc_cmap = np.zeros((target_len+binder_len, target_len+binder_len))
-        
         binder_hotspots = '26-35,55-59,102-116'
-        cdr_range = np.array(set_range(binder_hotspots))+target_len
-        
-        fc_cmap[-binder_len:,-binder_len:] = load_np
-        
-        for i in target_hotspots_np:
-            for x in cdr_range:
-                fc_cmap[x-1,i-1] = 1.
-                fc_cmap[i-1,x-1] = 1.
+        fc_cmap = assemble_fold_conditioned_cmap(load_np, target_len, binder_len,
+                                                 target_hotspots, binder_hotspots)
     else:
         pdbparser = PDBParser()
-        
+
         structure = pdbparser.get_structure(binder_template, template_pdb)
         chains = {chain.id:seq1(''.join(residue.resname for residue in chain)) for chain in structure.get_chains()}
-        
+
         query_chain = chains[chain_template]
-        
+
         af_binder = mk_afdesign_model(protocol="fixbb", use_templates=True)
         af_binder.prep_inputs(pdb_filename=template_pdb,
                              ignore_missing=False,
                              chain = chain_template,
                              rm_template_seq=False,
                              rm_template_sc=False,)
-        
+
         #name='9had'
         af_binder.set_seq(query_chain[:af_binder._len])
         af_binder.predict(num_recycles=3, verbose=False)
         print(f"CMAP of {binder_template} (monomer plddt: {af_binder.aux['log']['plddt']:.3f})")
         #plt.imshow(af_model.aux['cmap'])
-        
-        
+
+
         warnings.filterwarnings("ignore")
-        
+
         #Prepare target protein structure
-        
-        target_hotspots_np = np.array(set_range(target_hotspots))
-        
+
         af_model = mk_afdesign_model(protocol="fixbb", use_templates=True)
         af_model.prep_inputs(pdb_filename=pdb_target_path,
                              ignore_missing=False,
                              chain = chain_id,)
-        
+
         target_len = af_model._len
         binder_len = af_binder._len
-        
+
+        # binder cmap from the AlphaFold2 prediction of the binder monomer
         load_np = af_binder.aux['cmap']
-        
-        if binder_mask != '':
-            binder_mask = set_range(binder_mask)
-            for i in binder_mask:
-                load_np[i,:] = 0.
-                load_np[:,i] = 0.
-        
-        fc_cmap = np.zeros((target_len+binder_len, target_len+binder_len))
-        
-        if binder_hotspots == '':
-            cdr_range = np.array([range(0,binder_len)])+target_len
-        else:
-            cdr_range = np.array(set_range(binder_hotspots))+target_len
-        
-        fc_cmap[-binder_len:,-binder_len:] = load_np
-        
-        for i in target_hotspots_np:
-            for x in cdr_range:
-                fc_cmap[x-1,i-1] = 1.
-                fc_cmap[i-1,x-1] = 1.
-    
+        fc_cmap = assemble_fold_conditioned_cmap(load_np, target_len, binder_len,
+                                                 target_hotspots, binder_hotspots,
+                                                 binder_mask)
+
     from matplotlib import patches
     fig, ax = plt.subplots()
     plt.imshow(fc_cmap)
@@ -187,11 +162,10 @@ def main():
     ax.add_patch(rect)
     ax.add_patch(rect2)
     plt.savefig(f'{folder_name}/fold_cond_cmap.png')
-    
+
     np.save(f'{folder_name}/fold_cond_cmap.npy',fc_cmap)
-    
-    fc_cmap[fc_cmap>0] = 1
-    np.save(f'{folder_name}/fold_cond_cmap_mask.npy',fc_cmap)
+
+    np.save(f'{folder_name}/fold_cond_cmap_mask.npy', binarize_cmap(fc_cmap))
 
     # Start to design
 
@@ -236,9 +210,9 @@ def main():
     cmap_loss = []
 
     # Create folders to save outputs
-    os.system(f'mkdir {folder_name}/traj/')
-    os.system(f'mkdir {folder_name}/mpnn/')
-    os.system(f'mkdir {folder_name}/designs/')
+    os.makedirs(f'{folder_name}/traj/', exist_ok=True)
+    os.makedirs(f'{folder_name}/mpnn/', exist_ok=True)
+    os.makedirs(f'{folder_name}/designs/', exist_ok=True)
 
     # Generate N number of trajectories
     if sample == False:

--- a/FoldCraft_binder.py
+++ b/FoldCraft_binder.py
@@ -103,10 +103,7 @@ def main():
     model_name = 'v_48_010'
 
     if start_with==0:
-    	try:
-    	    os.system(f'mkdir {folder_name}')
-    	except:
-            pass  
+    	os.makedirs(folder_name, exist_ok=True)
     
     # Start to design
 
@@ -127,10 +124,10 @@ def main():
 
     # Create folders to save outputs
     if start_with == 0:
-    	os.system(f'mkdir {folder_name}/traj/')
-    	os.system(f'mkdir {folder_name}/mpnn/')
-    	os.system(f'mkdir {folder_name}/designs/')
-    	os.system(f'mkdir {folder_name}/relaxed/')
+    	os.makedirs(f'{folder_name}/traj/', exist_ok=True)
+    	os.makedirs(f'{folder_name}/mpnn/', exist_ok=True)
+    	os.makedirs(f'{folder_name}/designs/', exist_ok=True)
+    	os.makedirs(f'{folder_name}/relaxed/', exist_ok=True)
 
     # Generate N number of trajectories
     
@@ -259,8 +256,8 @@ def main():
                             df.to_csv(f"{folder_name}/results_pyrosetta.csv")
                             passed+=1
                         else:
-                            
-                            os.system(f'rm {mpnn_design_relaxed}')
+
+                            os.remove(mpnn_design_relaxed)
                         
                         
     

--- a/cmap_utils.py
+++ b/cmap_utils.py
@@ -1,0 +1,101 @@
+"""Pure (GPU-free) construction of the fold-conditioned contact map.
+
+The fold-conditioned cmap is the artifact the design loss conditions on, so it
+is the single most accuracy-relevant *deterministic* step in the pipeline. This
+module extracts its assembly out of ``FoldCraft.py``'s ``main()`` so it can be
+unit-tested and shared by both the standard and VHH paths (which previously
+duplicated the same logic inline).
+
+IMPORTANT: this is a *behavior-preserving* extraction, not a cleanup. The index
+arithmetic is reproduced exactly as in the original inline code, including:
+
+  - ``set_range``'s exclusive upper bound (``"39-45"`` -> 39..44);
+  - the residue-number -> array-index ``-1`` offsets;
+  - the quirky default branch ``np.array([range(0, binder_len)])`` (a 2-D
+    ``(1, binder_len)`` array that drives NumPy fancy-indexing in the contact
+    loop) used when no binder hotspots are given.
+
+Any change to these semantics alters design inputs and must be made
+deliberately and measured against the design baseline -- not folded into this
+extraction. See tests/test_cmap_utils.py, which pins the behavior with a
+verbatim reference implementation.
+"""
+import numpy as np
+
+from biopython_utils import set_range
+
+
+def apply_binder_mask(binder_cmap, binder_mask):
+    """Zero out masked binder rows/columns in the binder's intra-chain cmap.
+
+    Mirrors the original inline behavior, including using ``set_range``'s
+    1-based residue numbers directly as 0-based indices into ``binder_cmap``.
+    Operates on a copy; the input array is not mutated (the original mutated
+    ``af_binder.aux['cmap']`` in place, but nothing downstream reads it again,
+    so this is value-equivalent for the pipeline).
+    """
+    binder_cmap = np.array(binder_cmap, copy=True)
+    if binder_mask != '':
+        for i in set_range(binder_mask):
+            binder_cmap[i, :] = 0.
+            binder_cmap[:, i] = 0.
+    return binder_cmap
+
+
+def assemble_fold_conditioned_cmap(binder_cmap, target_len, binder_len,
+                                   target_hotspots, binder_hotspots,
+                                   binder_mask=''):
+    """Build the ``(target_len + binder_len)`` square fold-conditioned cmap.
+
+    Parameters
+    ----------
+    binder_cmap : array (binder_len x binder_len)
+        The binder's intra-chain contact map. In the standard path this comes
+        from an AlphaFold2 prediction of the binder monomer; in the VHH path it
+        is loaded from ``framework/vhh.npy``.
+    target_len, binder_len : int
+        Chain lengths. The binder block is placed in the bottom-right corner.
+    target_hotspots, binder_hotspots : str
+        Residue-range strings (e.g. ``"36-41,84-88"``). If ``binder_hotspots``
+        is the empty string, all binder residues are used (the original
+        default).
+    binder_mask : str, optional
+        Residue ranges in the binder to zero out before assembly. The VHH path
+        does not use a binder mask; pass ``''`` to match it.
+
+    Returns
+    -------
+    np.ndarray
+        The fold-conditioned cmap (float; target<->binder hotspot contacts
+        marked ``1.0``).
+    """
+    binder_cmap = apply_binder_mask(binder_cmap, binder_mask)
+
+    target_hotspots_np = np.array(set_range(target_hotspots))
+
+    fc_cmap = np.zeros((target_len + binder_len, target_len + binder_len))
+
+    if binder_hotspots == '':
+        cdr_range = np.array([range(0, binder_len)]) + target_len
+    else:
+        cdr_range = np.array(set_range(binder_hotspots)) + target_len
+
+    fc_cmap[-binder_len:, -binder_len:] = binder_cmap
+
+    for i in target_hotspots_np:
+        for x in cdr_range:
+            fc_cmap[x - 1, i - 1] = 1.
+            fc_cmap[i - 1, x - 1] = 1.
+
+    return fc_cmap
+
+
+def binarize_cmap(fc_cmap):
+    """Return the binary contact mask (any positive entry -> 1).
+
+    This is the ``cond_cmap_mask`` the design loop loads alongside the cmap.
+    Returns a copy; does not mutate the input.
+    """
+    mask = np.array(fc_cmap, copy=True)
+    mask[mask > 0] = 1
+    return mask

--- a/tests/test_cmap_utils.py
+++ b/tests/test_cmap_utils.py
@@ -1,0 +1,152 @@
+"""Tests for the fold-conditioned cmap extraction (cmap_utils.py).
+
+The centerpiece is a *differential* test: ``_reference_cmap`` reproduces the
+original inline logic from FoldCraft.py verbatim, and we assert the extracted
+``assemble_fold_conditioned_cmap`` produces bit-identical output across a range
+of inputs (standard, default-hotspot, masked, and VHH-like cases). This is the
+evidence that the extraction is behavior-preserving.
+
+There are also explicit small-case value tests, so a future change to the index
+semantics (e.g. fixing set_range's exclusive bound) trips a concrete assertion,
+not just the differential check.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+# Make the repo root importable so `import cmap_utils` works when this test runs
+# on its own (independently of a test-suite conftest.py).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cmap_utils as cu
+from biopython_utils import set_range
+
+
+# ---------------------------------------------------------------------------
+# Verbatim reference: the original inline assembly from FoldCraft.py main().
+# (The standard/non-VHH path, which subsumes the VHH path as a special case.)
+# ---------------------------------------------------------------------------
+def _reference_cmap(load_np, target_len, binder_len, target_hotspots,
+                    binder_hotspots, binder_mask):
+    load_np = np.array(load_np, copy=True)  # avoid cross-test mutation
+    if binder_mask != '':
+        binder_mask = set_range(binder_mask)
+        for i in binder_mask:
+            load_np[i, :] = 0.
+            load_np[:, i] = 0.
+
+    target_hotspots_np = np.array(set_range(target_hotspots))
+
+    fc_cmap = np.zeros((target_len + binder_len, target_len + binder_len))
+
+    if binder_hotspots == '':
+        cdr_range = np.array([range(0, binder_len)]) + target_len
+    else:
+        cdr_range = np.array(set_range(binder_hotspots)) + target_len
+
+    fc_cmap[-binder_len:, -binder_len:] = load_np
+
+    for i in target_hotspots_np:
+        for x in cdr_range:
+            fc_cmap[x - 1, i - 1] = 1.
+            fc_cmap[i - 1, x - 1] = 1.
+
+    return fc_cmap
+
+
+# Deterministic pseudo-random binder cmap (no Math.random/global-seed needed).
+def _fake_binder_cmap(binder_len, seed=0):
+    rng = np.random.default_rng(seed)
+    m = rng.random((binder_len, binder_len))
+    return (m + m.T) / 2.0  # symmetric, like a real contact map
+
+
+# (target_len, binder_len, target_hotspots, binder_hotspots, binder_mask)
+DIFFERENTIAL_CASES = [
+    (5, 4, "2-4", "1-3", ""),            # explicit binder hotspots
+    (5, 4, "2-4", "", ""),               # default: all binder residues
+    (6, 5, "1-3,5", "2-4", "2-3"),       # with a binder mask
+    (8, 6, "3-6", "1-2,4-6", ""),        # multiple hotspot ranges
+    (10, 127, "5-9,20", "26-35,55-59,102-116", ""),  # VHH-like geometry
+    (4, 3, "1", "1", ""),                # singletons
+]
+
+
+@pytest.mark.parametrize(
+    "target_len,binder_len,t_hot,b_hot,b_mask", DIFFERENTIAL_CASES
+)
+def test_matches_reference_implementation(target_len, binder_len, t_hot,
+                                          b_hot, b_mask):
+    binder_cmap = _fake_binder_cmap(binder_len)
+    expected = _reference_cmap(binder_cmap, target_len, binder_len,
+                               t_hot, b_hot, b_mask)
+    got = cu.assemble_fold_conditioned_cmap(
+        binder_cmap, target_len, binder_len, t_hot, b_hot, b_mask
+    )
+    np.testing.assert_array_equal(got, expected)
+
+
+# ---------------------------------------------------------------------------
+# Explicit value/structure checks
+# ---------------------------------------------------------------------------
+class TestStructure:
+    def test_shape_is_total_length(self):
+        bc = np.zeros((4, 4))
+        out = cu.assemble_fold_conditioned_cmap(bc, 5, 4, "2-3", "1-2", "")
+        assert out.shape == (9, 9)
+
+    def test_binder_block_placed_bottom_right(self):
+        bc = np.full((3, 3), 0.7)
+        out = cu.assemble_fold_conditioned_cmap(bc, 4, 3, "1", "", "")
+        # bottom-right 3x3 block holds the binder cmap values.
+        np.testing.assert_array_equal(out[-3:, -3:], bc)
+
+    def test_hotspot_contacts_are_symmetric(self):
+        bc = np.zeros((4, 4))
+        out = cu.assemble_fold_conditioned_cmap(bc, 5, 4, "2-4", "1-3", "")
+        np.testing.assert_array_equal(out, out.T)
+
+    def test_known_contact_entries(self):
+        # target_len=5, target_hotspots="2-3" -> set_range gives [2] (exclusive!)
+        # binder_hotspots="1-3" -> [1, 2]; cdr_range = [1,2] + 5 = [6, 7]
+        # contacts set at (x-1, i-1) and (i-1, x-1):
+        #   i=2 -> i-1=1 ; x in {6,7} -> x-1 in {5,6}
+        # => entries (5,1),(1,5),(6,1),(1,6) == 1
+        bc = np.zeros((4, 4))
+        out = cu.assemble_fold_conditioned_cmap(bc, 5, 4, "2-3", "1-3", "")
+        for r, c in [(5, 1), (1, 5), (6, 1), (1, 6)]:
+            assert out[r, c] == 1.0
+        # target residue 3 was dropped by the exclusive bound -> no (.,2) contacts
+        assert out[6, 2] == 0.0 and out[2, 6] == 0.0
+
+
+class TestApplyBinderMask:
+    def test_masks_rows_and_cols_without_mutating_input(self):
+        bc = np.ones((4, 4))
+        masked = cu.apply_binder_mask(bc, "1-3")  # set_range -> [1, 2]
+        assert np.all(masked[1, :] == 0) and np.all(masked[:, 1] == 0)
+        assert np.all(masked[2, :] == 0) and np.all(masked[:, 2] == 0)
+        # row/col 0 and 3 untouched at their intersection
+        assert masked[0, 3] == 1 and masked[3, 0] == 1
+        # input not mutated
+        assert np.all(bc == 1)
+
+    def test_empty_mask_is_identity_copy(self):
+        bc = np.arange(9).reshape(3, 3).astype(float)
+        out = cu.apply_binder_mask(bc, "")
+        np.testing.assert_array_equal(out, bc)
+        assert out is not bc  # still a copy
+
+
+class TestBinarize:
+    def test_positive_entries_become_one(self):
+        a = np.array([[0.0, 0.3], [2.5, 0.0]])
+        out = cu.binarize_cmap(a)
+        np.testing.assert_array_equal(out, np.array([[0.0, 1.0], [1.0, 0.0]]))
+
+    def test_does_not_mutate_input(self):
+        a = np.array([[0.0, 0.3]])
+        cu.binarize_cmap(a)
+        assert a[0, 1] == 0.3


### PR DESCRIPTION
## Summary

Two **behavior-preserving** cleanups to `FoldCraft.py` (and a small one to `FoldCraft_binder.py`), both **outside the stochastic design loop**, with tests. No design/algorithm behavior changes.

### 1. Extract the fold-conditioned cmap assembly into a pure module

The fold-conditioned contact map is the deterministic artifact the design loss conditions on. It was built inline in `main()` and **duplicated** across the VHH and standard paths. This moves it into a pure-numpy module:

- **`cmap_utils.py`** — `assemble_fold_conditioned_cmap()` (shared by both paths), `apply_binder_mask()`, `binarize_cmap()`.
- **`FoldCraft.py`** — both inline blocks replaced with calls; the GPU/model code (`af_binder.predict`, `prep_inputs`) is left exactly in place. The cmap is built *before* the design loop, so the RNG-sensitive path is untouched.
- This is a **verbatim** extraction: all index arithmetic is preserved, including `set_range`'s exclusive upper bound, the residue→index `-1` offsets, and the `np.array([range(0, binder_len)])` default branch.

### 2. Replace `os.system` shell-outs with Python `os` calls

- `os.system('mkdir ...')` → `os.makedirs(..., exist_ok=True)` (also removes a `try/except` that could never catch an `os.system` failure, and the duplicate-dir stderr noise on re-runs).
- `os.system('rm ...')` → `os.remove(...)`.
- Avoids shell invocation / quoting on output paths.

## Tests

`tests/test_cmap_utils.py` — **14 tests**, the key one a **differential test**: a verbatim reproduction of the original inline logic, asserted **bit-identical** to the extracted function across 6 cases (standard, default-hotspot, masked, VHH-like geometry). The test is self-contained (`pytest tests/test_cmap_utils.py`).

```
14 passed
```

## Notes

- **Not** runtime-verified end-to-end: the drivers import `colabdesign`/JAX and need a GPU. Verified via `py_compile`, the differential/unit tests, and a line-by-line argument-mapping review against the original.
- The known `set_range` off-by-one (`"39-45"` drops residue 45) is **intentionally preserved** here; a fix is a separate, behavior-changing change best measured against a design baseline.
- Independent of the companion test-suite and BindCraft-fix PRs; can be merged on its own, in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)