### PR TITLE
Fix BindCraft dependency so the binder pipeline imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ fold_cond_cmap.png
 # OS / editor
 .DS_Store
 *.swp
+
+# Local venv / test caches
+.venv/
+.pytest_cache/
+.coverage

--- a/bindcraft_deps.py
+++ b/bindcraft_deps.py
@@ -1,0 +1,104 @@
+"""Locate and expose the BindCraft utilities that FoldCraft's PyRosetta pipeline needs.
+
+``FoldCraft_binder.py`` reuses two functions from Martin Pacesa's BindCraft
+(https://github.com/martinpacesa/BindCraft):
+
+  - ``pr_relax(pdb_file, relaxed_pdb_path)``
+  - ``score_interface(pdb_file, binder_chain="B")``
+
+plus PyRosetta itself (conventionally imported as ``pr``) and the bundled
+``DAlphaBall.gcc`` binary used for interface "holes" scoring.
+
+BindCraft is a collection of scripts, not a pip-installable package, so it has
+to be cloned and placed on ``sys.path`` (the import is ``BindCraft.functions``,
+which resolves as a namespace package when BindCraft's *parent* directory is on
+the path). Upstream FoldCraft relied on an implicit ``from BindCraft.functions
+import *`` that (a) was never installed by ``install_foldcraft.sh`` and (b)
+silently shadowed FoldCraft's own ``biopython_utils`` helpers. This module
+makes the dependency explicit and fails with an actionable message when it is
+missing.
+
+The path-resolution logic here is intentionally free of any PyRosetta/BindCraft
+import so it can be unit-tested on a machine without the GPU design stack.
+"""
+import os
+import sys
+
+BINDCRAFT_REPO_URL = "https://github.com/martinpacesa/BindCraft"
+
+
+def _bindcraft_candidates(explicit_path=None):
+    """Ordered list of directories that might be (or contain) the BindCraft repo."""
+    candidates = []
+    if explicit_path:
+        candidates.append(explicit_path)
+    env = os.environ.get("BINDCRAFT_PATH")
+    if env:
+        candidates.append(env)
+    # Installer default: a ``BindCraft`` checkout next to this file.
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(os.path.join(here, "BindCraft"))
+    return candidates
+
+
+def _is_bindcraft_repo(path):
+    """True if ``path`` is a BindCraft checkout (has functions/__init__.py)."""
+    return os.path.isfile(os.path.join(path, "functions", "__init__.py"))
+
+
+def find_bindcraft_repo(explicit_path=None):
+    """Return the absolute path to the BindCraft repository directory.
+
+    A candidate matches if it either *is* a BindCraft checkout or *contains* a
+    ``BindCraft`` subdirectory that is one. Raises ``ImportError`` with install
+    instructions if none match.
+    """
+    for cand in _bindcraft_candidates(explicit_path):
+        cand = os.path.abspath(cand)
+        if _is_bindcraft_repo(cand):
+            return cand
+        nested = os.path.join(cand, "BindCraft")
+        if _is_bindcraft_repo(nested):
+            return nested
+    searched = [os.path.abspath(c) for c in _bindcraft_candidates(explicit_path)]
+    raise ImportError(
+        "FoldCraft's binder pipeline requires BindCraft, which was not found.\n"
+        "Re-run install_foldcraft.sh, or clone it manually:\n"
+        f"    git clone {BINDCRAFT_REPO_URL}\n"
+        "and/or set the BINDCRAFT_PATH environment variable to its location.\n"
+        f"Searched: {searched}"
+    )
+
+
+def ensure_bindcraft_importable(explicit_path=None):
+    """Put BindCraft's parent dir on ``sys.path`` so ``import BindCraft`` works.
+
+    Returns the BindCraft repository path. Idempotent.
+    """
+    repo = find_bindcraft_repo(explicit_path)
+    parent = os.path.dirname(repo)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    return repo
+
+
+def dalphaball_path(explicit_path=None):
+    """Absolute path to the DAlphaBall.gcc binary bundled with BindCraft.
+
+    Falls back to a ``./DAlphaBall.gcc`` in the current directory if present
+    (preserving upstream FoldCraft's behavior). Raises FileNotFoundError with
+    guidance otherwise.
+    """
+    repo = find_bindcraft_repo(explicit_path)
+    bundled = os.path.join(repo, "functions", "DAlphaBall.gcc")
+    if os.path.isfile(bundled):
+        return bundled
+    cwd_copy = os.path.abspath("DAlphaBall.gcc")
+    if os.path.isfile(cwd_copy):
+        return cwd_copy
+    raise FileNotFoundError(
+        "DAlphaBall.gcc not found. It ships with BindCraft at "
+        "functions/DAlphaBall.gcc and is required for interface holes scoring. "
+        "Re-run install_foldcraft.sh to set it up.\n"
+        f"Looked for: {bundled} and {cwd_copy}"
+    )

--- a/install_foldcraft.sh
+++ b/install_foldcraft.sh
@@ -93,6 +93,25 @@ echo -e "Installing ColabDesign\n"
 pip3 install git+https://github.com/sokrypton/ColabDesign.git --no-deps || { echo -e "Error: Failed to install ColabDesign"; exit 1; }
 python -c "import colabdesign" >/dev/null 2>&1 || { echo -e "Error: colabdesign module not found after installation"; exit 1; }
 
+# install BindCraft (provides pr_relax / score_interface used by FoldCraft_binder.py)
+# BindCraft is not a pip package; clone it next to FoldCraft so that
+# `import BindCraft.functions` resolves. Set BINDCRAFT_COMMIT to pin a revision
+# for reproducibility (recommended); empty = default branch.
+echo -e "Installing BindCraft\n"
+BINDCRAFT_COMMIT="${BINDCRAFT_COMMIT:-}"
+bindcraft_dir="${install_dir}/BindCraft"
+if [ ! -d "${bindcraft_dir}" ]; then
+    git clone https://github.com/martinpacesa/BindCraft "${bindcraft_dir}" || { echo -e "Error: Failed to clone BindCraft"; exit 1; }
+fi
+if [ -n "${BINDCRAFT_COMMIT}" ]; then
+    git -C "${bindcraft_dir}" checkout "${BINDCRAFT_COMMIT}" || { echo -e "Error: Failed to checkout BindCraft commit ${BINDCRAFT_COMMIT}"; exit 1; }
+fi
+[ -f "${bindcraft_dir}/functions/__init__.py" ] || { echo -e "Error: BindCraft checkout is missing functions/__init__.py"; exit 1; }
+# DAlphaBall.gcc (interface holes scoring) ships with BindCraft; ensure executable.
+[ -f "${bindcraft_dir}/functions/DAlphaBall.gcc" ] || { echo -e "Error: BindCraft is missing functions/DAlphaBall.gcc"; exit 1; }
+chmod +x "${bindcraft_dir}/functions/DAlphaBall.gcc" || { echo -e "Warning: could not chmod +x DAlphaBall.gcc"; }
+python -c "import sys; sys.path.insert(0, '${install_dir}'); from bindcraft_deps import find_bindcraft_repo; print('BindCraft at', find_bindcraft_repo())" || { echo -e "Error: BindCraft not importable via bindcraft_deps"; exit 1; }
+
 # AlphaFold2 weights
 echo -e "Downloading AlphaFold2 model weights \n"
 params_dir="${install_dir}/params"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Test dependencies for the CPU-only test suite (the GPU-free helper functions).
+# Lower-bound ranges so the suite resolves across supported Python versions.
+biopython>=1.83
+numpy>=1.26,<3
+scipy>=1.11
+pytest>=8

--- a/test/FoldCraft_binder.py
+++ b/test/FoldCraft_binder.py
@@ -43,8 +43,20 @@ from colabdesign.mpnn import mk_mpnn_model
 from biopython_utils import *
 import warnings
 
-from BindCraft.functions import *
-pr.init(f'-ignore_unrecognized_res -ignore_zero_occupancy -mute all -holes:dalphaball "./DAlphaBall.gcc" -corrections::beta_nov16 true -relax:default_repeats 1')
+# BindCraft provides the PyRosetta relax + interface-scoring helpers reused
+# below. It is not pip-installable, so locate the checkout (created by
+# install_foldcraft.sh or pointed to via $BINDCRAFT_PATH), put it on sys.path,
+# and import only what we use -- avoiding the previous `import *`, which both
+# failed when BindCraft was absent and shadowed FoldCraft's own biopython_utils.
+# This script lives in test/ but bindcraft_deps.py is at the repo root.
+import sys as _sys
+_sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from bindcraft_deps import ensure_bindcraft_importable, dalphaball_path
+ensure_bindcraft_importable()
+import pyrosetta as pr
+from BindCraft.functions.pyrosetta_utils import pr_relax, score_interface
+
+pr.init(f'-ignore_unrecognized_res -ignore_zero_occupancy -mute all -holes:dalphaball "{dalphaball_path()}" -corrections::beta_nov16 true -relax:default_repeats 1')
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Run fold-conditioned binder design")

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,48 @@
+# FoldCraft test suite
+
+This suite was added to give the project a regression safety net before we
+refactor or tune the design pipeline. Upstream FoldCraft shipped **no tests**.
+
+## What is covered
+
+These are **characterization tests**: they assert the *current* behavior of the
+GPU-free helper functions so that refactors and performance/accuracy work do not
+silently change residue selection, interface detection, or scoring.
+
+Covered today (all CPU-only, run on a laptop in seconds):
+
+- `biopython_utils.set_range` — hotspot/mask range parsing
+- `biopython_utils.calculate_percentages` — secondary-structure fractions
+- `biopython_utils.validate_design_sequence` — composition notes
+- `biopython_utils.calculate_clash_score` — clash counting (real PDB fixtures)
+- `biopython_utils.hotspot_residues` — interface detection (synthetic complex)
+- `biopython_utils.target_pdb_rmsd` — CA RMSD after superposition
+
+## Known issues the tests pin (not yet fixed)
+
+Some tests document behavior that is arguably a **latent bug**. They are named
+and commented with `BUG:` so the behavior is locked but flagged:
+
+- **`set_range` upper bound is exclusive.** `"39-45"` expands to `39..44`,
+  dropping residue 45; `"80-81"` yields only `[80]`; `"80-80"` yields `[]`.
+  This silently narrows every hotspot/mask window by one residue at the top and
+  is accuracy-relevant (it decides which residues the cmap loss conditions on).
+  Fixing it will change design inputs, so it must be done deliberately, with the
+  test updated in the same commit and a baseline re-run to confirm the effect.
+
+## What is NOT covered yet
+
+The two design drivers (`FoldCraft.py`, `FoldCraft_binder.py`) are monolithic
+`main()` functions requiring a GPU, AlphaFold2 weights, `colabdesign`, and the
+side-loaded `BindCraft` package (`from BindCraft.functions import *`, which is
+neither vendored nor declared). They have no importable seams. Covering them
+requires the planned refactor into testable units; that work is tracked
+separately.
+
+## Running
+
+```bash
+python -m venv .venv
+./.venv/bin/pip install -r requirements-dev.txt
+./.venv/bin/python -m pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,93 @@
+"""Shared fixtures for the FoldCraft test suite.
+
+These tests are *characterization* tests: they lock in the CURRENT behavior of
+the GPU-free helper functions so we can refactor and tune the design pipeline
+without silently changing residue selection, interface detection, or scoring.
+Where current behavior looks like a latent bug, the test documents it
+explicitly (see ``test_biopython_utils.py``) rather than asserting the
+"intended" behavior — so a future fix will trip the test and force a conscious
+decision.
+"""
+import os
+import sys
+
+import pytest
+from Bio.PDB import PDBIO
+from Bio.PDB.Structure import Structure
+from Bio.PDB.Model import Model
+from Bio.PDB.Chain import Chain
+from Bio.PDB.Residue import Residue
+from Bio.PDB.Atom import Atom
+
+# Make the repo root importable so `import biopython_utils` works regardless of
+# where pytest is invoked from.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+@pytest.fixture(scope="session")
+def pdb_1qys():
+    """Path to a real single-chain protein structure (Top7 / 1QYS template)."""
+    path = os.path.join(REPO_ROOT, "examples", "templates", "1qys1.pdb")
+    assert os.path.exists(path), f"missing test fixture: {path}"
+    return path
+
+
+@pytest.fixture(scope="session")
+def pdb_pdl1():
+    """Path to a real single-chain protein structure (PD-L1 target)."""
+    path = os.path.join(REPO_ROOT, "examples", "targets", "pd-l1-1.pdb")
+    assert os.path.exists(path), f"missing test fixture: {path}"
+    return path
+
+
+def _add_residue(chain, resseq, resname, atoms):
+    """Add a residue with the given (name, (x, y, z)) atoms to a chain."""
+    res = Residue((" ", resseq, " "), resname, "")
+    for i, (atom_name, coord) in enumerate(atoms):
+        atom = Atom(
+            atom_name,
+            coord,
+            0.0,          # bfactor
+            1.0,          # occupancy
+            " ",          # altloc
+            atom_name,    # fullname
+            i,            # serial_number
+            element=atom_name[0],
+        )
+        res.add(atom)
+    chain.add(res)
+    return res
+
+
+@pytest.fixture()
+def two_chain_complex(tmp_path):
+    """A minimal 2-chain complex written to disk, with a known interface.
+
+    Layout (CA-only, coordinates in Angstrom):
+      - chain A (target): residue 1 ALA at the origin.
+      - chain B (binder): residue 1 GLY ~3 A from chain A  -> interface contact
+                          residue 2 LEU ~20 A away          -> NOT a contact
+
+    With a 4.0 A cutoff, ``hotspot_residues(pdb, "B")`` should report exactly
+    binder residue 1 (GLY -> "G"). This pins interface detection, which drives
+    the non-interface ProteinMPNN redesign in the design pipeline.
+    """
+    structure = Structure("mini")
+    model = Model(0)
+    structure.add(model)
+
+    chain_a = Chain("A")
+    chain_b = Chain("B")
+    model.add(chain_a)
+    model.add(chain_b)
+
+    _add_residue(chain_a, 1, "ALA", [("CA", (0.0, 0.0, 0.0))])
+    _add_residue(chain_b, 1, "GLY", [("CA", (3.0, 0.0, 0.0))])
+    _add_residue(chain_b, 2, "LEU", [("CA", (20.0, 0.0, 0.0))])
+
+    out = tmp_path / "mini_complex.pdb"
+    io = PDBIO()
+    io.set_structure(structure)
+    io.save(str(out))
+    return str(out)

--- a/tests/test_bindcraft_deps.py
+++ b/tests/test_bindcraft_deps.py
@@ -1,0 +1,82 @@
+"""Tests for the BindCraft locator (bindcraft_deps.py).
+
+These exercise only the path-resolution logic, which is deliberately free of
+PyRosetta/BindCraft imports, so they run on a plain CPU machine. We fake a
+BindCraft checkout on disk rather than cloning the real one.
+"""
+import os
+import sys
+
+import pytest
+
+import bindcraft_deps as bd
+
+
+def _make_fake_bindcraft(root, with_dalphaball=True):
+    """Create a minimal BindCraft checkout layout under ``root``/BindCraft."""
+    repo = os.path.join(root, "BindCraft")
+    functions = os.path.join(repo, "functions")
+    os.makedirs(functions)
+    open(os.path.join(functions, "__init__.py"), "w").close()
+    if with_dalphaball:
+        open(os.path.join(functions, "DAlphaBall.gcc"), "w").close()
+    return repo
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    # Ensure a stray BINDCRAFT_PATH in the real environment can't leak in.
+    monkeypatch.delenv("BINDCRAFT_PATH", raising=False)
+
+
+class TestFindBindcraftRepo:
+    def test_explicit_path_is_the_repo(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path)
+        assert bd.find_bindcraft_repo(repo) == os.path.abspath(repo)
+
+    def test_explicit_path_is_the_parent(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path)
+        # Passing the parent dir should also resolve to the nested BindCraft.
+        assert bd.find_bindcraft_repo(str(tmp_path)) == os.path.abspath(repo)
+
+    def test_env_var_used(self, tmp_path, monkeypatch):
+        repo = _make_fake_bindcraft(tmp_path)
+        monkeypatch.setenv("BINDCRAFT_PATH", str(tmp_path))
+        assert bd.find_bindcraft_repo() == os.path.abspath(repo)
+
+    def test_missing_raises_with_instructions(self, tmp_path):
+        empty = tmp_path / "nothing"
+        empty.mkdir()
+        with pytest.raises(ImportError) as exc:
+            bd.find_bindcraft_repo(str(empty))
+        msg = str(exc.value)
+        assert "git clone" in msg and "BindCraft" in msg
+
+
+class TestEnsureImportable:
+    def test_inserts_parent_on_syspath_and_is_idempotent(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path)
+        parent = os.path.dirname(repo)
+        original = list(sys.path)
+        try:
+            bd.ensure_bindcraft_importable(repo)
+            assert parent in sys.path
+            count_after_first = sys.path.count(parent)
+            bd.ensure_bindcraft_importable(repo)
+            assert sys.path.count(parent) == count_after_first  # no duplicate
+        finally:
+            sys.path[:] = original
+
+
+class TestDalphaballPath:
+    def test_returns_bundled_binary(self, tmp_path):
+        repo = _make_fake_bindcraft(tmp_path, with_dalphaball=True)
+        expected = os.path.join(repo, "functions", "DAlphaBall.gcc")
+        assert bd.dalphaball_path(repo) == expected
+
+    def test_missing_binary_raises(self, tmp_path, monkeypatch):
+        repo = _make_fake_bindcraft(tmp_path, with_dalphaball=False)
+        # Run from a dir with no ./DAlphaBall.gcc fallback either.
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            bd.dalphaball_path(repo)

--- a/tests/test_biopython_utils.py
+++ b/tests/test_biopython_utils.py
@@ -1,0 +1,135 @@
+"""Characterization tests for biopython_utils.py.
+
+Goal: lock the CURRENT behavior of the GPU-free helpers before we refactor or
+tune the design pipeline. Several tests document behavior that is arguably a
+bug (notably the exclusive upper bound in ``set_range``); they are marked with
+a `BUG:` note. When we deliberately fix one, the corresponding test should be
+updated in the same commit so the change is explicit and reviewed.
+"""
+import pytest
+
+import biopython_utils as bu
+
+
+# ---------------------------------------------------------------------------
+# set_range  -- parses hotspot/mask range strings like "39-45,80,90-102"
+# This drives every hotspot/mask selection, so its semantics are
+# accuracy-critical: it decides which residues the cmap loss conditions on.
+# ---------------------------------------------------------------------------
+class TestSetRange:
+    def test_single_residue(self):
+        assert bu.set_range("80") == [80]
+
+    def test_comma_separated_singletons(self):
+        assert bu.set_range("80,90,102") == [80, 90, 102]
+
+    def test_range_is_upper_bound_EXCLUSIVE(self):
+        # BUG (characterized, not endorsed): "39-45" expands to 39..44 and
+        # DROPS the endpoint 45, because the implementation uses
+        # range(start, end) with no +1. A user typing "39-45" almost certainly
+        # means residues 39 through 45 inclusive. This silently narrows every
+        # hotspot/mask window by one residue at the top.
+        assert bu.set_range("39-45") == [39, 40, 41, 42, 43, 44]
+        assert 45 not in bu.set_range("39-45")
+
+    def test_mixed_ranges_and_singletons(self):
+        # Singletons keep their value; ranges drop their endpoint.
+        assert bu.set_range("14-30,80-81,90-102") == (
+            list(range(14, 30)) + [80] + list(range(90, 102))
+        )
+
+    def test_single_width_range_yields_empty(self):
+        # BUG (characterized): "80-81" yields only [80]; "80-80" yields [].
+        assert bu.set_range("80-81") == [80]
+        assert bu.set_range("80-80") == []
+
+    def test_order_preserved(self):
+        assert bu.set_range("90-92,10") == [90, 91, 10]
+
+
+# ---------------------------------------------------------------------------
+# calculate_percentages -- pure arithmetic for secondary-structure fractions
+# ---------------------------------------------------------------------------
+class TestCalculatePercentages:
+    def test_basic_split(self):
+        # total=10, helix=5, sheet=3 -> loop=2
+        assert bu.calculate_percentages(10, 5, 3) == (50.0, 30.0, 20.0)
+
+    def test_zero_total_is_safe(self):
+        assert bu.calculate_percentages(0, 0, 0) == (0, 0, 0)
+
+    def test_all_helix(self):
+        assert bu.calculate_percentages(4, 4, 0) == (100.0, 0.0, 0.0)
+
+    def test_rounding_to_two_decimals(self):
+        # 1/3 -> 33.33
+        h, s, l = bu.calculate_percentages(3, 1, 1)
+        assert h == 33.33 and s == 33.33 and l == 33.33
+
+
+# ---------------------------------------------------------------------------
+# validate_design_sequence -- composition notes for a designed sequence
+# ---------------------------------------------------------------------------
+class TestValidateDesignSequence:
+    def test_clean_high_absorption_sequence_no_notes(self):
+        # Tryptophan-rich sequence => high extinction => no absorption warning.
+        settings = {"omit_AAs": ""}
+        notes = bu.validate_design_sequence("WWWWYYYY", 0, settings)
+        assert notes == ""
+
+    def test_clash_note(self):
+        settings = {"omit_AAs": ""}
+        notes = bu.validate_design_sequence("WWWWYYYY", 3, settings)
+        assert "clashes" in notes
+
+    def test_omitted_aa_flagged(self):
+        settings = {"omit_AAs": "C"}
+        notes = bu.validate_design_sequence("WWCWYY", 0, settings)
+        assert "Contains: C" in notes
+
+    def test_low_absorption_suggests_tryptophan(self):
+        settings = {"omit_AAs": ""}
+        notes = bu.validate_design_sequence("AAAAGGGG", 0, settings)
+        assert "tryptophane" in notes.lower()
+
+
+# ---------------------------------------------------------------------------
+# calculate_clash_score -- C-alpha / heavy-atom clash counting on a real PDB
+# ---------------------------------------------------------------------------
+class TestCalculateClashScore:
+    def test_real_structure_has_no_ca_clashes(self, pdb_1qys):
+        # A well-formed deposited structure should have no CA-CA clashes
+        # between non-adjacent residues at the 2.4 A default threshold.
+        assert bu.calculate_clash_score(pdb_1qys, only_ca=True) == 0
+
+    def test_returns_int(self, pdb_pdl1):
+        score = bu.calculate_clash_score(pdb_pdl1, only_ca=True)
+        assert isinstance(score, int)
+
+
+# ---------------------------------------------------------------------------
+# hotspot_residues -- interface residue detection (drives MPNN redesign mask)
+# ---------------------------------------------------------------------------
+class TestHotspotResidues:
+    def test_detects_only_close_binder_residue(self, two_chain_complex):
+        result = bu.hotspot_residues(two_chain_complex, binder_chain="B")
+        # Only binder residue 1 (GLY) is within 4.0 A of chain A.
+        assert result == {1: "G"}
+
+    def test_wider_cutoff_includes_far_residue(self, two_chain_complex):
+        # At a 25 A cutoff both binder residues contact chain A.
+        result = bu.hotspot_residues(
+            two_chain_complex, binder_chain="B", atom_distance_cutoff=25.0
+        )
+        assert set(result.keys()) == {1, 2}
+        assert result[2] == "L"
+
+
+# ---------------------------------------------------------------------------
+# target_pdb_rmsd -- CA RMSD after superposition
+# ---------------------------------------------------------------------------
+class TestTargetPdbRmsd:
+    def test_self_alignment_is_zero(self, pdb_1qys):
+        # Aligning a structure's chain A against itself must give ~0 RMSD.
+        rmsd = bu.target_pdb_rmsd(pdb_1qys, pdb_1qys, "A")
+        assert rmsd == 0.0


### PR DESCRIPTION
`test/FoldCraft_binder.py` does `from BindCraft.functions import *`, but `install_foldcraft.sh` never installs/clones BindCraft — so the experimental binder pipeline fails to import out of the box. The wildcard also shadows the script's own `biopython_utils` helpers.

- **`bindcraft_deps.py`**: locates a BindCraft checkout (explicit arg / `$BINDCRAFT_PATH` / `./BindCraft`), puts it on `sys.path`, resolves the bundled `DAlphaBall.gcc`, and raises actionable errors. Import-free path logic → unit-testable without the GPU/PyRosetta stack.
- **`test/FoldCraft_binder.py`**: import only what's used (`pr_relax`, `score_interface`, `pyrosetta as pr`); resolve DAlphaBall via `dalphaball_path()`; repo-root `sys.path` insert (the script lives in `test/`, `bindcraft_deps.py` at the root).
- **`install_foldcraft.sh`**: clone BindCraft (pinnable via `$BINDCRAFT_COMMIT`), verify layout + DAlphaBall, check importability.
- **`tests/test_bindcraft_deps.py`**: 7 locator tests using a faked checkout.

Not runtime-verified end-to-end (PyRosetta/GPU); locator tests pass and signatures match the call sites. **Stacked on #9** (merge that first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)